### PR TITLE
Fix CI workflow: Create virtual environment before installing dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,33 +26,41 @@ jobs:
       run: |
         python -m pip install uv
     
-    - name: Install dependencies
+    - name: Create virtual environment and install dependencies
       run: |
+        uv venv
+        . .venv/bin/activate
         uv pip install -e ".[dev]"
     
     - name: Lint with ruff
       run: |
-        uv run ruff check --fix .
+        . .venv/bin/activate
+        ruff check --fix .
         
     - name: Check formatting with black
       run: |
-        uv run black --check .
+        . .venv/bin/activate
+        black --check .
         
     - name: Check imports with isort
       run: |
-        uv run isort --check .
+        . .venv/bin/activate
+        isort --check .
         
     - name: Type check with mypy
       run: |
-        uv run mypy --strict .
+        . .venv/bin/activate
+        mypy --strict .
         
     - name: Test with pytest
       run: |
-        uv run pytest --cov=timeless_py
+        . .venv/bin/activate
+        pytest --cov=timeless_py
         
     - name: Check coverage threshold
       run: |
-        uv run python -c "import sys, xml.etree.ElementTree as ET; \
+        . .venv/bin/activate
+        python -c "import sys, xml.etree.ElementTree as ET; \
         coverage = float(ET.parse('coverage.xml').getroot().attrib['line-rate']) * 100; \
         sys.exit(0 if coverage >= 90 else 1)" || \
         (echo "::error::Coverage below threshold: ${coverage}%"; exit 1)


### PR DESCRIPTION
This PR fixes the CI workflow issue by:

1. Creating a virtual environment with `uv venv` before installing dependencies
2. Activating the virtual environment for each step in the workflow
3. Using the installed tools directly instead of through `uv run`

This should resolve the error: "No virtual environment found; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment"